### PR TITLE
Give textareas a default background colour.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -118,6 +118,7 @@ button,
 select,
 textarea {
 	color: #555;
+	background-color: white;
 	line-height: 1.2em;
 	padding: 3px 5px;
 }
@@ -142,6 +143,7 @@ input:focus,
 textarea:focus {
 	border-color: #888;
 	color: #303030;
+	background-color: white;
 	outline: 0;
 }
 textarea:disabled {


### PR DESCRIPTION
My default background colour for textareas is inherited from my OS
colours, which is a dark grey. Thus setting a foreground colour
without setting a background colour makes it impossible for me to type
in textareas. This patch should fix that.