### PR TITLE
Add explanation of traffic number in logo title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
       <div id="headerleft">
         <a id="l_holder" style="background-color: #<%= sprintf("%02x%02x%02x",
         [ 255, (@traffic * 7).floor + 50.0 ].min, 0, 0) %>;" href="/"
-        title="<%= Rails.application.name %> (<%= @traffic.to_i %>)"></a>
+        title="<%= Rails.application.name %> (Current traffic: <%= @traffic.to_i %>)"></a>
 
         <% links = {
           "/" => @cur_url == "/" ? Rails.application.name : "Home",


### PR DESCRIPTION
Since it keeps getting [asked](https://lobste.rs/s/gve5zg/why_does_the_lobsters_l_icon_change_color).

Of course open to different wording.