### PR TITLE
more flexible url regexp validation

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -46,7 +46,7 @@ class Story < ActiveRecord::Base
     if self.url.present?
       # URI.parse is not very lenient, so we can't use it
 
-      if self.url.match(/\Ahttps?:\/\/([^\.]+\.)+[a-z]+(\/|\z)/)
+      if self.url.match(/\A^https?:\/\/([^\s:@]+:[^\s:@]*@)?[-[[:alnum:]]]+(\.[-[[:alnum:]]]+)+\.?(:\d{1,5})?([\/?]\S*)?$\z/iux)
         if self.new_record? && (s = Story.find_similar_by_url(self.url))
           self.already_posted_story = s
           if s.is_recent?


### PR DESCRIPTION
like railscasts #301 but with \A and \z ruby features
https://github.com/railscasts/301-extracting-a-ruby-gem/blob/master/url_formatter/lib/url_formatter.rb

for example with old regexp I couldnot submit a story with url like HTTPS://lobste.rs/, but now I can.