### PR TITLE
Keep the www\d* domain for some stories

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -258,10 +258,11 @@ class Story < ActiveRecord::Base
     else
       # URI.parse is not very lenient, so we can't use it
       self.url.
-        gsub(/^[^:]+:\/\//, ""). # proto
-        gsub(/\/.*/, "").        # path
-        gsub(/:\d+$/, "").       # possible port
-        gsub(/^www\d*\./, "")    # possible "www3." in host
+        gsub(/^[^:]+:\/\//, "").        # proto
+        gsub(/\/.*/, "").               # path
+        gsub(/:\d+$/, "").              # possible port
+        gsub(/^www\d*\.(.+\..+)/, '\1') # possible "www3." in host unless
+                                        # it's the only non-TLD
     end
   end
 


### PR DESCRIPTION
When extracting story domain, keep the facing `www\d*` domain in cases
where it's the only non top level domain (e.g. www31337.tld).

That may seem like an odd case, but i've seen a story on the www10.org domain today and it had a broken domain and, consequently wrong search by domain link.