### PR TITLE
Indicate if a story has a description

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -26,6 +26,9 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
           "original submitter" %>]
       <% end %>
     </span>
+    <% if story.markeddown_description.present? %>
+      <span class="description_present">&#FE19;</span>
+    <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
       <span class="tags">
         <% story.sorted_taggings.each do |tagging| %>
@@ -34,9 +37,6 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             title="<%= tagging.tag.description %>"><%= tagging.tag.tag %></a>
         <% end %>
       </span>
-      <% if story.markeddown_description.present? %>
-        <span class="description_present">&para;</span>
-      <% end %>
       <% if story.domain.present? %>
         <a class="domain" href="<%= story.domain_search_url %>"><%=
           break_long_words(story.domain) %></a>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -34,6 +34,9 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             title="<%= tagging.tag.description %>"><%= tagging.tag.tag %></a>
         <% end %>
       </span>
+      <% if story.markdown_description.present? %>
+        <span class="description_present">&para;</span>
+      <% end %>
       <% if story.domain.present? %>
         <a class="domain" href="<%= story.domain_search_url %>"><%=
           break_long_words(story.domain) %></a>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -34,7 +34,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             title="<%= tagging.tag.description %>"><%= tagging.tag.tag %></a>
         <% end %>
       </span>
-      <% if story.markdown_description.present? %>
+      <% if story.markeddown_description.present? %>
         <span class="description_present">&para;</span>
       <% end %>
       <% if story.domain.present? %>


### PR DESCRIPTION
To encourage folks to write story descriptions on links, let's mark stories with descriptions so that folks know to click through.

The pilcrow is a little visually heavy, but it seemed better than an arbitrary symbol.