### PR TITLE
Add tooltip for the ︙ marking description_present

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -27,7 +27,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
       <% end %>
     </span>
     <% if story.markeddown_description.present? %>
-      <span class="description_present">&#xFE19;</span>
+      <span class="description_present" title="this story has a description">&#xFE19;</span>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
       <span class="tags">


### PR DESCRIPTION
When I saw that only some of the stories had the ‘︙’ symbol, I was mystified. It looked like a drag handle, but didn’t react to anything. I only figured out its purpose by using the developer tools and seeing that it had the class `description_present`.

This `title` attribute allows the user to see the meaning of the symbol, by hovering over it.