### PR TITLE
Show comments link even if there are no comments

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -158,7 +158,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             (hidden by <%= pluralize(story.hider_count, "user") %>)
           <% end %>
         <% end %>
-        <% if !story.is_gone? && (@user || story.comments_count > 0) %>
+        <% if !story.is_gone? %>
           <span class="comments_label">
             |
             <a href="<%= story.comments_path %>"><%= story.comments_count == 0 ?


### PR DESCRIPTION
For stories with both text and a link that have no comments, the only way to view the text is to either log in (no account :( ) or view the page source and find the story ID. This commit fixes that by always showing the comments link.