### PR TITLE
Update byline for non-authored submissions.

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -69,11 +69,11 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
                 srcset="<%= ms.user.avatar_url(16) %> 1x,
                 <%= ms.user.avatar_url(32) %> 2x" class="avatar"></a>
             <% end %>
-
             <% if story.user_is_author? %>
-              authored
+              authored by
+            <% else %>
+              via
             <% end %>
-            by
             <a href="/u/<%= ms.user.username %>" class="<%=
               ms.html_class_for_user %>"><%= ms.user.username %></a>
 
@@ -99,16 +99,21 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
           srcset="<%= story.user.avatar_url(16) %> 1x,
           <%= story.user.avatar_url(32) %> 2x" class="avatar"></a>
       <% end %>
-      <% if story.user_is_author? %>
-        authored
-      <% end %>
       <% if story.previewing %>
-        by
+        <% if story.user_is_author? %>
+          authored by
+        <% else %>
+          via
+        <% end %>
         <a class="<%= story.html_class_for_user %>"><%=
           story.user.username %></a>
         just now
       <% else %>
-        by
+        <% if story.user_is_author? %>
+          authored by
+        <% else %>
+          via
+        <% end %>
         <a href="/u/<%= story.user.username %>" class="<%=
           story.html_class_for_user %>"><%= story.user.username %></a>
 


### PR DESCRIPTION
(I couldn't find any indication that this was previously discussed and didn't feel like the effort involved was too great to avoid working on it before discussion, so... here's a PR. Close at will)

I love the recent addition of the 'authored by' checkbox, but unfortunately, the distinction between 'authored by' and 'by' is too subtle to be picked up without careful attention (at least for me). I tend to see 'by' as implicitly including 'authored ', because I don't tend to read the whole byline, just the '... by &lt;username&gt;.' Naturally, this leads to confusion on my part.

This PR makes a subtle change to the byline of stories. Instead of attempting to classify the type of attribution with a modifier (e.g. 'authored', or potentially 'submitted'), it avoids the use of 'by' all together for non-authored submissions, choosing 'via' instead. 'via' may not be the correct choice, but, to me, implies 'discovery' not 'authorship.' and is easily separated visually from 'by'.

Comments remain unchanged, of course, as they are always authored by, and attributed to the commenter.