### PR TITLE
Remove white background from .legend

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -975,7 +975,6 @@ table.data td p:last-child {
 }
 
 .box .legend {
-	background-color: white;
 	margin-bottom: 1em;
 	padding: 0;
 	font-weight: bold;


### PR DESCRIPTION
I am not entirely sure about this... but it feels like the `background-color: white;` on `.legend` is not intentional?

It currently creates a subtle odd appearance on pages like `/settings` and `/filters` where the section headers pop out because the background color is different than the rest of the page.