### PR TITLE
Add script to ease setup for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,75 +16,49 @@ site unless you are contributing code that will also benefit [lobste.rs](https:/
 Please see the [CONTRIBUTING](https://github.com/jcs/lobsters/blob/master/CONTRIBUTING.md)
 file.
 
-####Initial setup
+####Development setup
 
-* Install Ruby. Supported Ruby versions include 1.9.3, 2.0.0 and 2.1.0.
+Prerequisites:
+* A supported ruby (1.9.3, 2.0.0, 2.1.0)
+* MySQL
+* Sphinx (if you want to use full-text search in development).
 
-* Checkout the lobsters git tree from Github
+Checkout the lobsters git tree from Github
 
-         $ git clone git://github.com/jcs/lobsters.git
-         $ cd lobsters
-         lobsters$ 
+    $ git clone git://github.com/jcs/lobsters.git
+    $ cd lobsters
+    lobsters$
 
-* Run Bundler to install/bundle gems needed by the project:
+Run `bin/setup` to install gem dependencies, initialize a secret key, setup the
+local database, and seed with test users.
 
-         lobsters$ bundle
+To use full-text search capabilities, run Sphinx with:
 
-* Create a MySQL (other DBs supported by ActiveRecord may work, only MySQL and
-MariaDB have been tested) database, username, and password and put them in a
-`config/database.yml` file:
+    lobsters$ rake ts:rebuild
 
-          development:
-            adapter: mysql2
-            encoding: utf8mb4
-            reconnect: false
-            database: lobsters_dev
-            socket: /tmp/mysql.sock
-            username: *username*
-            password: *password*
-            
-          test:
-            adapter: sqlite3
-            database: db/test.sqlite3
-            pool: 5
-            timeout: 5000
+Run the Rails server in development mode.  You should be able to login to
+`http://localhost:3000` with your new `test` user:
 
-* Load the schema into the new database:
+    lobsters$ rails server
 
-          lobsters$ rake db:schema:load
+####Customizing for your own deployment of Lobsters
 
 * Create a `config/initializers/secret_token.rb` file, using a randomly
 generated key from the output of `rake secret`:
 
-          Lobsters::Application.config.secret_key_base = 'your random secret here'
-
-* (Optional, only needed for the search engine) Install Sphinx.  Build Sphinx
-config and start server:
-
-          lobsters$ rake ts:rebuild
+    Lobsters::Application.config.secret_key_base = 'your random secret here'
 
 * Define your site's name and default domain, which are used in various places,
 in a `config/initializers/production.rb` or similar file:
 
-          class << Rails.application
-            def domain
-              "example.com"
-            end
-          
-            def name
-              "Example News"
-            end
-          end
-          
-          Rails.application.routes.default_url_options[:host] = Rails.application.domain
+    class << Rails.application
+      def domain
+        "example.com"
+      end
 
-* Seed the database to create an initial administrator user and at least one tag:
+      def name
+        "Example News"
+      end
+    end
 
-          lobsters$ rake db:seed
-          created user: test, password: test
-          created tag: test
-
-* Run the Rails server in development mode.  You should be able to login to
-`http://localhost:3000` with your new `test` user:
-
-          lobsters$ rails server
+    Rails.application.routes.default_url_options[:host] = Rails.application.domain

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Exit if any subcommand fails
+set -e
+
+# Set up Ruby dependencies via Bundler
+gem install bundler --conservative
+bundle check || bundle install
+
+# Create a secret key
+echo 'Lobsters::Application.config.secret_key_base = "'$(bundle exec rake secret)'"'
+
+# Setup the database
+cp config/database.example.yml config/database.yml
+bundle exec rake db:reset

--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -1,0 +1,12 @@
+development:
+  adapter: mysql2
+  encoding: utf8mb4
+  reconnect: false
+  database: lobsters_dev
+  socket: /tmp/mysql.sock
+
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000


### PR DESCRIPTION
Some of the steps in the README are not necessary if all you want to do
is contribute back to Lobsters, rather than run your own instance.
Additionally, the steps that are necessary can be scripted without too
much hassle. `bin/setup` will produce a runnable local version of the
application (without Sphinx).

I also updated the README to break up the instructions for running a
local version of Lobsters and configuring your own version for
deployment.
