### PR TITLE
Fixes #272. Add runSelect2 method to call after previewStory.

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -196,7 +196,48 @@ var _Lobsters = Class.extend({
   },
 
   previewStory: function(form) {
-    $("#inside").load("/stories/preview", $(form).serializeArray());
+    $("#inside").load("/stories/preview", $(form).serializeArray(),
+    function() {
+      Lobsters.runSelect2();
+    });
+  },
+
+  runSelect2: function() {
+    $("#story_tags_a").select2({
+    formatSelection: function(what) {
+      return what.id;
+    },
+    matcher: function(term, text) {
+      return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;
+    },
+    sortResults: function(results, container, query) {
+        if (query.term) {
+          var tmatches = [];
+          var dmatches = [];
+
+          /* prefer tag matches first, then description matches */
+          for (var x in results) {
+            var r = results[x];
+
+            if (r.id.toUpperCase().indexOf(query.term.toUpperCase()) == 0)
+              tmatches.push(r);
+            else
+              dmatches.push(r);
+          }
+
+          tmatches = tmatches.sort(function(a, b) {
+            return a.text.localeCompare(b.text);
+          });
+          dmatches = dmatches.sort(function(a, b) {
+            return a.text.localeCompare(b.text);
+          });
+
+          return tmatches.concat(dmatches);
+        }
+
+        return results;
+    }
+    });
   },
 
   moderateStory: function(link) {
@@ -390,41 +431,7 @@ $(document).ready(function() {
     }
   });
 
-  $("#story_tags_a").select2({
-    formatSelection: function(what) {
-      return what.id;
-    },
-    matcher: function(term, text) {
-      return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;
-    },
-    sortResults: function(results, container, query) {
-        if (query.term) {
-          var tmatches = [];
-          var dmatches = [];
-
-          /* prefer tag matches first, then description matches */
-          for (var x in results) {
-            var r = results[x];
-
-            if (r.id.toUpperCase().indexOf(query.term.toUpperCase()) == 0)
-              tmatches.push(r);
-            else
-              dmatches.push(r);
-          }
-
-          tmatches = tmatches.sort(function(a, b) {
-            return a.text.localeCompare(b.text);
-          });
-          dmatches = dmatches.sort(function(a, b) {
-            return a.text.localeCompare(b.text);
-          });
-
-          return tmatches.concat(dmatches);
-        }
-
-        return results;
-    }
-  });
+  Lobsters.runSelect2();
 
   $(document).on("click", "div.markdown_help_toggler .markdown_help_label",
   function() {


### PR DESCRIPTION
The select2 code failed to run after previewing a story
submission. This fix creates a new method that can be called upon
completion of the previewStory load() call.