### PR TITLE
Clean up mysqlism (booleans are also usable as int(1))

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
       @title << " By Karma"
       render :action => "list"
     elsif params[:moderators]
-      @users = User.where("is_admin = true OR is_moderator = true").
+      @users = User.where("is_admin = ? OR is_moderator = ?", true, true).
         order("id ASC").to_a
       @user_count = @users.length
       @title = "Moderators and Administrators"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
       @title << " By Karma"
       render :action => "list"
     elsif params[:moderators]
-      @users = User.where("is_admin = 1 OR is_moderator = 1").
+      @users = User.where("is_admin = true OR is_moderator = true").
         order("id ASC").to_a
       @user_count = @users.length
       @title = "Moderators and Administrators"


### PR DESCRIPTION
MySQL used to implement booleans as int(1) and preserves that behavior for backwards compatability. Postgres doesn't, so I was throwing 500s.

I audited all the other booleans, didn't catch any other use of 1 and 0.