### PR TITLE
Add RSS and JSON feeds for newest by user

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -108,7 +108,13 @@ class HomeController < ApplicationController
     @newest = true
     @for_user = by_user.username
 
-    render :action => "index"
+    respond_to do |format|
+      format.html { render :action => "index" }
+      format.rss {
+        render :action => "rss", :layout => false
+      }
+      format.json { render :json => @stories }
+    end
   end
 
   def recent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Lobsters::Application.routes.draw do
 
     get "/newest" => "home#newest", :format => /html|json|rss/
     get "/newest/page/:page" => "home#newest"
-    get "/newest/:user" => "home#newest_by_user"
+    get "/newest/:user" => "home#newest_by_user", :format => /html|json|rss/
     get "/newest/:user/page/:page" => "home#newest_by_user"
     get "/recent" => "home#recent"
     get "/recent/page/:page" => "home#recent"


### PR DESCRIPTION
This makes their behaviour consistent with /newest and /t/:tag

Use case: I'd like to be able to trigger IFTTT events when I post stuff to lobste.rs, and the RSS feed would allow me to do that. I don't actually need the .json feed but it seemed to make more sense to have it behave the same way as the other pages that expose RSS feeds.

I couldn't find any tests for the RSS and JSON functionality, so I haven't added any for this either. If I've missed something, please let me know and I'll add some. I have run all the existing tests and this doesn't break anything. I've also tested it manually to verify that the JSON and RSS feeds work as expected.

I did this as a PR rather than an issue because it took all of five minutes and it seemed likely to be lower effort to just submit it as one than discuss it in a separate issue first. It's of course fine if you want to reject it.