### PR TITLE
Fix error when a tag has no stories yet

### DIFF
--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -5,7 +5,7 @@
 
   <% max_size = @tags.map{|t| t.stories_count }.max %>
   <% @tags.each do |tag| %>
-    <% mod = (max_size.to_f / tag.stories_count.to_f) %>
+    <% mod = (max_size.to_f / ((tag.stories_count.to_f == 0) ? 1 : tag.stories_count.to_f )) %>
     <%= link_to tag.tag, tag_path(tag), :class => tag.css_class,
       :style => "text-decoration: none; vertical-align: middle; " <<
       "font-size: #{((52 / (mod + 1)) + 8).ceil}pt; line-height: 1.5em;" %>


### PR DESCRIPTION
When mod is calculated, if stories_count of a tag is zero, 0 is divided by 0, giving NaN and a error. 
If stories_count of a tag is 0, divide by 1 instead thus this error is fixed. 
This will have prolonged difference since oncea tag gets atleast one story our pre-defined 1 won't be used.