### PR TITLE
Typo fix: "has mention" -> "mentioned"

### DIFF
--- a/app/views/email_reply/mention.text.erb
+++ b/app/views/email_reply/mention.text.erb
@@ -1,4 +1,4 @@
-<%= @comment.user.username %> has mention you in a comment:
+<%= @comment.user.username %> mentioned you in a comment:
 
   <%= word_wrap(@comment.plaintext_comment, :line_width => 72).gsub(/\n/, "\n  ") %>
 


### PR DESCRIPTION
Noticed this in the email notification: "amontalenti has mention you in a comment" -> "amontalenti mentioned you in a comment"