### PR TITLE
Prevent comment textarea from exceeding width of container

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -837,6 +837,10 @@ div.comment_form_container form {
 	max-width: 700px;
 }
 
+div.comment_form_container textarea {
+	box-sizing: border-box;
+	width: 100%;
+}
 
 /* trees */
 

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -15,7 +15,7 @@ data-shortid="<%= comment.short_id if comment.persisted? %>">
 
   <div style="width: 100%;">
     <%= text_area_tag "comment", comment.comment, :rows => 5,
-      :style => "width: 100%;", :autocomplete => "off", :disabled => !@user,
+      :autocomplete => "off", :disabled => !@user,
       :placeholder => (@user ? "" : "You must be logged in to leave a comment.")
       %>
 


### PR DESCRIPTION
Before:
<img width="370" alt="screen shot 2017-01-06 at 10 13 39 am" src="https://cloud.githubusercontent.com/assets/602654/21726242/2a0dfe0a-d3f9-11e6-8a43-dc4e8b5e855a.png">

After:
<img width="371" alt="screen shot 2017-01-06 at 10 14 03 am" src="https://cloud.githubusercontent.com/assets/602654/21726249/2eef3c7c-d3f9-11e6-9b0b-5d1b0997b0d1.png">
