### PR TITLE
Hide number input spinner buttons for TOTP inputs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -232,6 +232,12 @@ button:disabled {
 	color: gray;
 }
 
+.totp_code::-webkit-inner-spin-button,
+.totp_code::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 
 /* outliners */
 

--- a/app/views/login/twofa.html.erb
+++ b/app/views/login/twofa.html.erb
@@ -11,7 +11,7 @@
     <p>
     <%= label_tag :totp_code, "TOTP Code:" %>
     <%= number_field_tag :totp_code, "", :size => 10, :autocomplete => "off",
-        :autofocus => true %>
+        :autofocus => true, :class => "totp_code" %>
     <br />
     </p>
 

--- a/app/views/login/twofa.html.erb
+++ b/app/views/login/twofa.html.erb
@@ -10,8 +10,8 @@
 
     <p>
     <%= label_tag :totp_code, "TOTP Code:" %>
-    <%= text_field_tag :totp_code, "", :size => 10, :type => "number",
-      :autofocus => "autofocus" %>
+    <%= number_field_tag :totp_code, "", :size => 10, :autocomplete => "off",
+        :autofocus => true %>
     <br />
     </p>
 

--- a/app/views/settings/twofa_verify.html.erb
+++ b/app/views/settings/twofa_verify.html.erb
@@ -14,8 +14,8 @@
 
     <div class="boxline">
       <%= label_tag :totp_code, "TOTP Code:", :class => "required" %>
-      <%= text_field_tag :totp_code, "", :size => 10, :autocomplete => "off",
-        :type => "number", :autofocus => "autofocus" %>
+      <%= number_field_tag :totp_code, "", :size => 10, :autocomplete => "off",
+          :autofocus => true %>
     </div>
 
     <p>

--- a/app/views/settings/twofa_verify.html.erb
+++ b/app/views/settings/twofa_verify.html.erb
@@ -15,7 +15,7 @@
     <div class="boxline">
       <%= label_tag :totp_code, "TOTP Code:", :class => "required" %>
       <%= number_field_tag :totp_code, "", :size => 10, :autocomplete => "off",
-          :autofocus => true %>
+          :autofocus => true, :class => "totp_code" %>
     </div>
 
     <p>


### PR DESCRIPTION
This hides the arrow buttons that WebKit displays for number inputs for TOTP code inputs.

E.g.,
<img width="174" alt="screen shot 2017-02-25 at 8 04 25 am" src="https://cloud.githubusercontent.com/assets/602654/23332120/4b484db4-fb31-11e6-8306-f9cbf6cb325c.png">
