### PR TITLE
Update views with email entry to use email field

### DIFF
--- a/app/views/invitations/build.html.erb
+++ b/app/views/invitations/build.html.erb
@@ -24,7 +24,7 @@
     <br />
 
     <%= f.label :email, "E-mail Address:" %>
-    <%= f.text_field :email, :size => 30 %>
+    <%= f.email_field :email, :size => 30 %>
     <br />
 
     <%= f.label :memo, "URL:" %>

--- a/app/views/login/forgot_password.html.erb
+++ b/app/views/login/forgot_password.html.erb
@@ -10,7 +10,7 @@
 
   <%= form_tag reset_password_path do %>
     <%= label_tag :email, "E-mail or Username:" %>
-    <%= text_field_tag :email, "", :size => 30 %>
+    <%= email_field_tag :email, "", :size => 30 %>
     <br />
 
     <p>

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -6,7 +6,7 @@
   <%= form_tag login_path do %>
   <p>
     <%= label_tag :email, "E-mail or Username:" %>
-    <%= text_field_tag :email, "", :size => 30, :autofocus => "autofocus" %>
+    <%= email_field_tag :email, "", :size => 30, :autofocus => "autofocus" %>
     <br />
 
     <%= label_tag :password, "Password:" %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -38,7 +38,7 @@
 
     <div class="boxline">
       <%= f.label :email, "E-mail Address:", :class => "required" %>
-      <%= f.text_field :email, :size => 40 %>
+      <%= f.email_field :email, :size => 40 %>
       <span class="hint">
         <a href="http://www.gravatar.com/" target="_blank">Gravatar</a>'ized
       </span>

--- a/app/views/users/_invitationform.html.erb
+++ b/app/views/users/_invitationform.html.erb
@@ -12,7 +12,7 @@ don't personally know.
 
   <div class="boxline">
     <%= label_tag :email, "E-mail Address:", :class => "required" %>
-    <%= text_field_tag :email, "", :size => 30, :autocomplete => "off" %>
+    <%= email_field_tag :email, "", :size => 30, :autocomplete => "off" %>
   </div>
 
   <div class="boxline">


### PR DESCRIPTION
The views that have been updated:

- settings/index
- invitations/build
- login/forgot_password
- invitation partial
- login/index

In each of these views, there is an email entry input.  This change
sets all of the input types to `email` instead of `text`.  This change
is important because without it, mobile browsers (especially on iOS)
will try to spell check the field which doesn't make sense for an email
address.

Issue: #349 