### PR TITLE
Use CommonMarker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "rqrcode"
 
 gem "nokogiri", "= 1.6.1"
 gem "htmlentities"
-gem "rdiscount"
+gem "commonmarker", "~> 0.14"
 
 gem "activerecord-typedstore"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
     bcrypt (3.1.7)
     builder (3.2.3)
     chunky_png (1.3.8)
+    commonmarker (0.14.15)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     dynamic_form (1.1.4)
@@ -107,7 +109,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (12.0.0)
-    rdiscount (2.1.7.1)
     riddle (1.5.11)
     rotp (3.3.0)
     rqrcode (0.10.1)
@@ -129,6 +130,8 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-enum (0.7.1)
+      i18n
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -162,6 +165,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-typedstore
   bcrypt (~> 3.1.2)
+  commonmarker (~> 0.14)
   dynamic_form
   exception_notification
   faker
@@ -173,7 +177,6 @@ DEPENDENCIES
   nokogiri (= 1.6.1)
   oauth
   rails (= 4.2.8)
-  rdiscount
   rotp
   rqrcode
   rspec-rails (~> 3.5, >= 3.5.2)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ActiveRecord::Base
 
   VALID_USERNAME = /[A-Za-z0-9][A-Za-z0-9_-]{0,24}/
   validates :username,
-    :format => { :with => /\A#{VALID_USERNAME}\Z/ },
+    :format => { :with => /\A#{VALID_USERNAME}\z/ },
     :uniqueness => { :case_sensitive => false }
 
   validates_each :username do |record,attr,value|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,8 +55,9 @@ class User < ActiveRecord::Base
 
   validates :password, :presence => true, :on => :create
 
+  VALID_USERNAME = /[A-Za-z0-9][A-Za-z0-9_-]{0,24}/
   validates :username,
-    :format => { :with => /\A[A-Za-z0-9][A-Za-z0-9_-]{0,24}\Z/ },
+    :format => { :with => /\A#{VALID_USERNAME}\Z/ },
     :uniqueness => { :case_sensitive => false }
 
   validates_each :username do |record,attr,value|

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -44,7 +44,7 @@ class Markdowner
 
   def self.postprocess_text_node(node)
     while node
-      return unless node.string_content =~ /\B(@[\w\-]+)/
+      return unless node.string_content =~ /\B(@#{User::VALID_USERNAME})/
       before, user, after = $`, $1, $'
 
       node.string_content = before

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -27,7 +27,7 @@ class Markdowner
 
     # make links have rel=nofollow
     ng.css("a").each do |h|
-      h[:rel] = "nofollow" unless URI.parse(h[:href]).host.nil?
+      h[:rel] = "nofollow" unless (URI.parse(h[:href]).host.nil? rescue false)
     end
 
     ng.at_css("body").inner_html

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -9,6 +9,11 @@ class Markdowner
 
     exts = [:tagfilter, :autolink]
     root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
+
+    unless opts[:disable_profile_links]
+      walk_text_nodes(root) {|n| postprocess_text_node(n)}
+    end
+
     ng = Nokogiri::HTML(root.to_html([:SAFE], exts))
 
     # change <h1>, <h2>, etc. headings to just bold tags
@@ -22,34 +27,51 @@ class Markdowner
 
     # make links have rel=nofollow
     ng.css("a").each do |h|
-      h[:rel] = "nofollow"
+      h[:rel] = "nofollow" unless h[:href].starts_with?("/")
     end
-
-    # XXX: t.replace(tx) unescapes HTML, so disable for now.  this probably
-    # needs to split text into separate nodes and then replace the @username
-    # with a proper 'a' node
-if false
-    unless opts[:disable_profile_links]
-      # make @username link to that user's profile
-      ng.search("//text()").each do |t|
-        if t.parent && t.parent.name.downcase == "a"
-          # don't replace inside <a>s
-          next
-        end
-
-        tx = t.text.gsub(/\B\@([\w\-]+)/) do |u|
-          if User.exists?(:username => u[1 .. -1])
-            "<a href=\"/u/#{u[1 .. -1]}\">#{u}</a>"
-          else
-            u
-          end
-        end
-
-        t.replace(tx)
-      end
-    end
-end
 
     ng.at_css("body").inner_html
+  end
+
+  def self.walk_text_nodes(node, &block)
+    return if node.type == :link
+    return block.call(node) if node.type == :text
+
+    node.each do |child|
+      walk_text_nodes(child, &block)
+    end
+  end
+
+  def self.postprocess_text_node(node)
+    while node
+      return unless node.string_content =~ /\B(@[\w\-]+)/
+      before, user, after = $`, $1, $'
+
+      node.string_content = before
+
+      if User.exists?(:username => user[1..-1])
+        link = CommonMarker::Node.new(:link)
+        link.url = "/u/#{user[1..-1]}"
+        node.insert_after(link)
+
+        link_text = CommonMarker::Node.new(:text)
+        link_text.string_content = user
+        link.append_child(link_text)
+
+        node = link
+      else
+        node.string_content += user
+      end
+
+      if after.length > 0
+        remainder = CommonMarker::Node.new(:text)
+        remainder.string_content = after
+        node.insert_after(remainder)
+
+        node = remainder
+      else
+        node = nil
+      end
+    end
   end
 end

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -27,7 +27,7 @@ class Markdowner
 
     # make links have rel=nofollow
     ng.css("a").each do |h|
-      h[:rel] = "nofollow" unless h[:href].starts_with?("/")
+      h[:rel] = "nofollow" unless URI.parse(h[:href]).host.nil?
     end
 
     ng.at_css("body").inner_html

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -7,17 +7,17 @@ class Markdowner
       return ""
     end
 
-    args = [ :smart, :autolink, :safelink, :filter_styles, :filter_html,
-      :strict ]
-    if !opts[:allow_images]
-      args.push :no_image
-    end
-
-    ng = Nokogiri::HTML(RDiscount.new(text.to_s, *args).to_html)
+    exts = [:tagfilter, :autolink]
+    root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
+    ng = Nokogiri::HTML(root.to_html([:SAFE], exts))
 
     # change <h1>, <h2>, etc. headings to just bold tags
     ng.css("h1, h2, h3, h4, h5, h6").each do |h|
       h.name = "strong"
+    end
+
+    if !opts[:allow_images]
+      ng.css("img").remove
     end
 
     # make links have rel=nofollow

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -7,7 +7,7 @@ class Markdowner
       return ""
     end
 
-    exts = [:tagfilter, :autolink]
+    exts = [:tagfilter, :autolink, :strikethrough]
     root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
 
     unless opts[:disable_profile_links]

--- a/spec/models/markdowner_spec.rb
+++ b/spec/models/markdowner_spec.rb
@@ -35,4 +35,17 @@ describe Markdowner do
       "<p>hi <a href=\"http://example.com/@blahblah/\" rel=\"nofollow\">" <<
         "test</a></p>"
   end
+
+  it "correctly adds nofollow" do
+    Markdowner.to_html("[ex](http://example.com)").should ==
+      "<p><a href=\"http://example.com\" rel=\"nofollow\">" <<
+        "ex</a></p>"
+
+    Markdowner.to_html("[ex](//example.com)").should ==
+      "<p><a href=\"//example.com\" rel=\"nofollow\">" <<
+        "ex</a></p>"
+
+    Markdowner.to_html("[ex](/u/abc)").should ==
+      "<p><a href=\"/u/abc\">ex</a></p>"
+  end
 end

--- a/spec/models/markdowner_spec.rb
+++ b/spec/models/markdowner_spec.rb
@@ -6,6 +6,16 @@ describe Markdowner do
       "<p>hello there <em>italics</em> and <strong>bold</strong>!</p>"
   end
 
+  it "turns @username into a link if @username exists" do
+    User.make!(:username => "blahblah")
+
+    Markdowner.to_html("hi @blahblah test").should ==
+      "<p>hi <a href=\"/u/blahblah\">@blahblah</a> test</p>"
+
+    Markdowner.to_html("hi @flimflam test").should ==
+      "<p>hi @flimflam test</p>"
+  end
+
   # bug#209
   it "keeps punctuation inside of auto-generated links when using brackets" do
     Markdowner.to_html("hi <http://example.com/a.> test").should ==


### PR DESCRIPTION
Fixes #288. We add CommonMark compatibility, strikethrough, `@username` expansion (with a kinda awkward AST walk, but it's simple if verbose), and with any luck general malleability going forward.