### PR TITLE
Upgrade nokogiri, jquery-rails and uglifier to secure version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "mysql2", ">= 0.3.14"
 gem "thinking-sphinx", "~> 3.1.2"
 
 gem "uglifier", ">= 1.3.0"
-gem "jquery-rails"
+gem "jquery-rails", "~> 3.1.3"
 gem "dynamic_form"
 
 gem "exception_notification"
@@ -24,7 +24,7 @@ gem "bcrypt", "~> 3.1.2"
 gem "rotp"
 gem "rqrcode"
 
-gem "nokogiri", "= 1.6.1"
+gem "nokogiri", ">= 1.7.2"
 gem "htmlentities"
 gem "commonmarker", "~> 0.14"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     exception_notification (4.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
-    execjs (2.2.1)
+    execjs (2.7.0)
     faker (1.4.2)
       i18n (~> 0.5)
     globalid (0.3.7)
@@ -60,10 +60,9 @@ GEM
     innertube (1.1.0)
     joiner (0.3.4)
       activerecord (>= 4.1.0)
-    jquery-rails (3.1.1)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (2.0.3)
     kgio (2.9.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -74,13 +73,13 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile (0.5.3)
-    minitest (5.10.1)
+    mini_portile2 (2.1.0)
+    minitest (5.10.2)
     mysql2 (0.3.20)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.7.2)
+      mini_portile2 (~> 2.1.0)
     oauth (0.4.7)
-    rack (1.6.5)
+    rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.8)
@@ -149,11 +148,10 @@ GEM
       riddle (>= 1.5.11)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    uglifier (2.5.3)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.2.0)
+      execjs (>= 0.3.0, < 3)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -170,11 +168,11 @@ DEPENDENCIES
   exception_notification
   faker
   htmlentities
-  jquery-rails
+  jquery-rails (~> 3.1.3)
   machinist
   mail
   mysql2 (>= 0.3.14)
-  nokogiri (= 1.6.1)
+  nokogiri (>= 1.7.2)
   oauth
   rails (= 4.2.8)
   rotp


### PR DESCRIPTION
Resolves the following security issues (surfaced by `bundle-audit`)
- https://github.com/mishoo/UglifyJS2/issues/751
- https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
- https://groups.google.com/forum/#!topic/ruby-security-ann/XIZPbobuwaY

We launched [Dependabot](https://dependabot.com) on Lobsters last week with a blog post about dependency security, so I figured this was the least I could do to say thanks! :)