### PR TITLE
Use _target instead of _new in href target

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -167,7 +167,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
         <% if story.url.present? %>
           |
           <a href="<%= story.archive_url %>" rel="nofollow"
-            target="_new">cached</a>
+            target="_blank">cached</a>
         <% end %>
         <% if !story.is_gone? %>
           <span class="comments_label">


### PR DESCRIPTION
"new" is a reserved keyword not allowed to use for browsing context in HTML5 (as well as HTML4 and XHTML) as per § 6.1.5 in the HTML5 specification. Instead use "_blank" to ensure a new browsing context. The use of "new" cause HTML validation of the frontpage to fail currently.