### PR TITLE
update rspec syntax

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,20 +3,25 @@ require "spec_helper"
 describe ApplicationHelper do
   describe "#page_numbers_for_pagination" do
     it "returns the right number of pages" do
-      helper.page_numbers_for_pagination(10, 1).should ==
-        [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+      expect(helper.page_numbers_for_pagination(10, 1)).
+        to eq([ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ])
 
-      helper.page_numbers_for_pagination(20, 1).should ==
-        [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "...", 20 ]
 
-      helper.page_numbers_for_pagination(25, 1).should ==
-        [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "...", 25 ]
+      expect(helper.page_numbers_for_pagination(20, 1)).
+        to eq([ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "...", 20 ])
 
-      helper.page_numbers_for_pagination(25, 10).should ==
-        [ 1, "...", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, "...", 25 ]
 
-      helper.page_numbers_for_pagination(25, 20).should ==
-        [ 1, "...", 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ]
+      expect(helper.page_numbers_for_pagination(25, 1)).
+        to eq([ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "...", 25 ])
+
+
+      expect(helper.page_numbers_for_pagination(25, 10)).
+        to eq([ 1, "...", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, "...", 25 ])
+
+
+      expect(helper.page_numbers_for_pagination(25, 20)).
+        to eq([ 1, "...", 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ])
+
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,6 +4,6 @@ describe Comment do
   it "should get a short id" do
     c = Comment.make!(:comment => "hello")
 
-    c.short_id.should match(/^\A[a-zA-Z0-9]{1,10}\z/)
+    expect(c.short_id).to match(/^\A[a-zA-Z0-9]{1,10}\z/)
   end
 end

--- a/spec/models/email_parser_spec.rb
+++ b/spec/models/email_parser_spec.rb
@@ -27,14 +27,14 @@ describe EmailParser do
       "-#{@emailer.mailing_list_token}@example.org",
       @emails["1"])
 
-    parser.should_not == nil
-    parser.email.should_not == nil
+    expect(parser).to_not be_nil
+    expect(parser.email).to_not be_nil
 
-    parser.user_token.should == @emailer.mailing_list_token
-    parser.been_here?.should == false
-    parser.sending_user.id.should == @emailer.id
+    expect(parser.user_token).to eq(@emailer.mailing_list_token)
+    expect(parser.been_here?).to be false
+    expect(parser.sending_user.id).to eq(@emailer.id)
 
-    parser.parent.class.should == Comment
+    expect(parser.parent.class).to be Comment
   end
 
   it "rejects mailing loops" do
@@ -44,8 +44,8 @@ describe EmailParser do
       "-#{@emailer.mailing_list_token}@example.org",
       @emails["2"])
 
-    parser.email.should_not == nil
-    parser.been_here?.should == true
+    expect(parser.email).to_not be_nil
+    expect(parser.been_here?).to be true
   end
 
   it "strips signatures" do
@@ -55,8 +55,9 @@ describe EmailParser do
       "-#{@emailer.mailing_list_token}@example.org",
       @emails["3"])
 
-    parser.email.should_not == nil
-    parser.body.should == "It hasn't decreased any measurable amount but since the traffic to\nthe site is increasing a bit each week, it's hard to tell."
+    expect(parser.email).to_not be_nil
+    expect(parser.body).
+      to eq("It hasn't decreased any measurable amount but since the traffic to\nthe site is increasing a bit each week, it's hard to tell.")
   end
 
   it "strips quoted lines with attribution" do
@@ -66,7 +67,8 @@ describe EmailParser do
       "-#{@emailer.mailing_list_token}@example.org",
       @emails["4"])
 
-    parser.email.should_not == nil
-    parser.body.should == "It hasn't decreased any measurable amount but since the traffic to\nthe site is increasing a bit each week, it's hard to tell."
+    expect(parser.email).to_not be_nil
+    expect(parser.body).
+      to eq("It hasn't decreased any measurable amount but since the traffic to\nthe site is increasing a bit each week, it's hard to tell.")
   end
 end

--- a/spec/models/markdowner_spec.rb
+++ b/spec/models/markdowner_spec.rb
@@ -2,50 +2,56 @@ require "spec_helper"
 
 describe Markdowner do
   it "parses simple markdown" do
-    Markdowner.to_html("hello there *italics* and **bold**!").should ==
-      "<p>hello there <em>italics</em> and <strong>bold</strong>!</p>"
+    expect(Markdowner.to_html("hello there *italics* and **bold**!")).
+      to eq("<p>hello there <em>italics</em> and <strong>bold</strong>!</p>\n")
+
   end
 
   it "turns @username into a link if @username exists" do
     User.make!(:username => "blahblah")
 
-    Markdowner.to_html("hi @blahblah test").should ==
-      "<p>hi <a href=\"/u/blahblah\">@blahblah</a> test</p>"
+    expect(Markdowner.to_html("hi @blahblah test")).
+      to eq("<p>hi <a href=\"/u/blahblah\">@blahblah</a> test</p>\n")
 
-    Markdowner.to_html("hi @flimflam test").should ==
-      "<p>hi @flimflam test</p>"
+
+    expect(Markdowner.to_html("hi @flimflam test")).
+      to eq("<p>hi @flimflam test</p>\n")
   end
 
   # bug#209
   it "keeps punctuation inside of auto-generated links when using brackets" do
-    Markdowner.to_html("hi <http://example.com/a.> test").should ==
-      "<p>hi <a href=\"http://example.com/a.\" rel=\"nofollow\">" <<
-        "http://example.com/a.</a> test</p>"
+    expect(Markdowner.to_html("hi <http://example.com/a.> test")).
+      to eq("<p>hi <a href=\"http://example.com/a.\" rel=\"nofollow\">" +
+            "http://example.com/a.</a> test</p>\n")
   end
 
   # bug#242
   it "does not expand @ signs inside urls" do
     User.make!(:username => "blahblah")
 
-    Markdowner.to_html("hi http://example.com/@blahblah/ test").should ==
-      "<p>hi <a href=\"http://example.com/@blahblah/\" rel=\"nofollow\">" <<
-        "http://example.com/@blahblah/</a> test</p>"
+    expect(Markdowner.to_html("hi http://example.com/@blahblah/ test")).
+      to eq("<p>hi <a href=\"http://example.com/@blahblah/\" rel=\"nofollow\">" +
+            "http://example.com/@blahblah/</a> test</p>\n")
 
-    Markdowner.to_html("hi [test](http://example.com/@blahblah/)").should ==
-      "<p>hi <a href=\"http://example.com/@blahblah/\" rel=\"nofollow\">" <<
-        "test</a></p>"
+    expect(Markdowner.to_html("hi [test](http://example.com/@blahblah/)")).
+      to eq("<p>hi <a href=\"http://example.com/@blahblah/\" rel=\"nofollow\">" +
+        "test</a></p>\n")
+
   end
 
   it "correctly adds nofollow" do
-    Markdowner.to_html("[ex](http://example.com)").should ==
-      "<p><a href=\"http://example.com\" rel=\"nofollow\">" <<
-        "ex</a></p>"
+    expect(Markdowner.to_html("[ex](http://example.com)")).
+      to eq("<p><a href=\"http://example.com\" rel=\"nofollow\">" +
+            "ex</a></p>\n")
 
-    Markdowner.to_html("[ex](//example.com)").should ==
-      "<p><a href=\"//example.com\" rel=\"nofollow\">" <<
-        "ex</a></p>"
 
-    Markdowner.to_html("[ex](/u/abc)").should ==
-      "<p><a href=\"/u/abc\">ex</a></p>"
+    expect(Markdowner.to_html("[ex](//example.com)")).
+      to eq("<p><a href=\"//example.com\" rel=\"nofollow\">" +
+            "ex</a></p>\n")
+
+
+    expect(Markdowner.to_html("[ex](/u/abc)")).
+      to eq("<p><a href=\"/u/abc\">ex</a></p>\n")
+
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -3,6 +3,6 @@ require "spec_helper"
 describe Message do
   it "should get a short id" do
     m = Message.make!
-    m.short_id.should match(/^\A[a-zA-Z0-9]{1,10}\z/)
+    expect(m.short_id).to match(/^\A[a-zA-Z0-9]{1,10}\z/)
   end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -4,7 +4,7 @@ describe Story do
   it "should get a short id" do
     s = Story.make!(:title => "hello", :url => "http://example.com/")
 
-    s.short_id.should match(/^\A[a-zA-Z0-9]{1,10}\z/)
+    expect(s.short_id).to match(/^\A[a-zA-Z0-9]{1,10}\z/)
   end
 
   it "requires a url or a description" do
@@ -44,81 +44,81 @@ describe Story do
   end
 
   it "checks for a previously posted story with same url" do
-    Story.count.should == 0
+    expect(Story.count).to eq(0)
 
     Story.make!(:title => "flim flam", :url => "http://example.com/")
-    Story.count.should == 1
+    expect(Story.count).to eq(1)
 
     expect { Story.make!(:title => "flim flam 2",
       :url => "http://example.com/") }.to raise_error
 
-    Story.count.should == 1
+    expect(Story.count).to eq(1)
 
     expect { Story.make!(:title => "flim flam 2",
       :url => "http://www.example.com/") }.to raise_error
 
-    Story.count.should == 1
+    expect(Story.count).to eq(1)
   end
 
   it "parses domain properly" do
     s = Story.make!(:url => "http://example.com")
-    s.domain.should == "example.com"
+    expect(s.domain).to eq("example.com")
 
     s = Story.make!(:url => "http://www3.example.com/goose")
-    s.domain.should == "example.com"
+    expect(s.domain).to eq("example.com")
 
     s = Story.make!(:url => "http://flub.example.com")
-    s.domain.should == "flub.example.com"
+    expect(s.domain).to eq("flub.example.com")
   end
 
   it "converts a title to a url properly" do
     s = Story.make!(:title => "Hello there, this is a title")
-    s.title_as_url.should == "hello_there_this_is_title"
+    expect(s.title_as_url).to eq("hello_there_this_is_title")
 
     s = Story.make!(:title => "Hello _ underscore")
-    s.title_as_url.should == "hello_underscore"
+    expect(s.title_as_url).to eq("hello_underscore")
 
     s = Story.make!(:title => "Hello, underscore")
-    s.title_as_url.should == "hello_underscore"
+    expect(s.title_as_url).to eq("hello_underscore")
 
     s = Story.make(:title => "The One-second War (What Time Will You Die?) ")
-    s.title_as_url.should == "one_second_war_what_time_will_you_die"
+    expect(s.title_as_url).to eq("one_second_war_what_time_will_you_die")
   end
 
   it "is not editable by another non-admin user" do
     u = User.make!
 
     s = Story.make!(:user_id => u.id)
-    s.is_editable_by_user?(u).should == true
+    expect(s.is_editable_by_user?(u)).to be true
 
     u = User.make!
-    s.is_editable_by_user?(u).should == false
+    expect(s.is_editable_by_user?(u)).to be false
   end
 
   it "can fetch its title properly" do
     s = Story.make
     s.fetched_content = File.read(Rails.root +
       "spec/fixtures/story_pages/1.html")
-    s.fetched_attributes[:title].should == "B2G demo & quick hack // by Paul Rouget"
+    expect(s.fetched_attributes[:title]).to eq("B2G demo & quick hack // by Paul Rouget")
 
     s = Story.make
     s.fetched_content = File.read(Rails.root +
       "spec/fixtures/story_pages/2.html")
-    s.fetched_attributes[:title].should == "Google"
+    expect(s.fetched_attributes[:title]).to eq("Google")
   end
 
   it "sets the url properly" do
     s = Story.make(:title => "blah")
     s.url = "https://factorable.net/"
     s.valid?
-    s.url.should == "https://factorable.net/"
+    expect(s.url).to eq("https://factorable.net/")
   end
 
   it "calculates tag changes properly" do
     s = Story.make!(:title => "blah", :tags_a => [ "tag1", "tag2" ])
 
     s.tags_a = [ "tag2" ]
-    s.tagging_changes.should == { "tags" => [ "tag1 tag2", "tag2" ] }
+    expect(s.tagging_changes).to eq({ "tags" => [ "tag1 tag2", "tag2" ] })
   end
 
   it "logs moderations properly" do
@@ -136,10 +136,10 @@ describe Story do
     s.save!
 
     mod_log = Moderation.last
-    mod_log.moderator_user_id.should == mod.id
-    mod_log.story_id.should == s.id
-    mod_log.reason.should == "because i hate you"
-    mod_log.action.should match(/title from "blah" to "changed title"/)
-    mod_log.action.should match(/tags from "tag1 tag2" to "tag1"/)
+    expect(mod_log.moderator_user_id).to eq(mod.id)
+    expect(mod_log.story_id).to eq(s.id)
+    expect(mod_log.reason).to eq("because i hate you")
+    expect(mod_log.action).to match(/title from "blah" to "changed title"/)
+    expect(mod_log.action).to match(/tags from "tag1 tag2" to "tag1"/)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,10 +23,10 @@ describe User do
   it "authenticates properly" do
     u = User.make!(:password => "hunter2")
 
-    u.password_digest.length.should > 20
+    expect(u.password_digest.length).to be > 20
 
-    u.authenticate("hunter2").should == u
-    u.authenticate("hunteR2").should == false
+    expect(u.authenticate("hunter2")).to eq(u)
+    expect(u.authenticate("hunteR2")).to be false
   end
 
   it "gets an error message after registering banned name" do
@@ -36,26 +36,26 @@ describe User do
   it "shows a user is banned or not" do
     u = User.make!(:banned)
     user = User.make!
-    u.is_banned?.should == true
-    user.is_banned?.should == false
+    expect(u.is_banned?).to be true
+    expect(user.is_banned?).to be false
   end
 
   it "shows a user is active or not" do
     u = User.make!(:banned)
     user = User.make!
-    u.is_active?.should == false
-    user.is_active?.should == true
+    expect(u.is_active?).to be false
+    expect(user.is_active?).to be true
   end
 
   it "shows a user is recent or not" do
     user = User.make!(:created_at => Time.now)
     u = User.make!(:created_at => Time.now - 8.days)
-    user.is_new?.should == true
-    u.is_new?.should == false
+    expect(user.is_new?).to be true
+    expect(u.is_new?).to be false
   end
 
   it "unbans a user" do
     u = User.make!(:banned)
-    u.unban_by_user!(User.first).should == true
+    expect(u.unban_by_user!(User.first)).to be true
   end
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -4,9 +4,9 @@ describe Vote do
   it "applies a story upvote and karma properly" do
     s = Story.make!
 
-    s.upvotes.should == 1
-    s.downvotes.should == 0
-    s.user.karma.should == 0
+    expect(s.upvotes).to eq(1)
+    expect(s.downvotes).to eq(0)
+    expect(s.user.karma).to eq(0)
 
     u = User.make!
 
@@ -15,8 +15,8 @@ describe Vote do
 
     s.reload
 
-    s.upvotes.should == 2
-    s.user.karma.should == 1
+    expect(s.upvotes).to eq(2)
+    expect(s.user.karma).to eq(1)
   end
 
   it "does nothing when upvoting an existing upvote" do
@@ -30,48 +30,48 @@ describe Vote do
 
       s.reload
 
-      s.upvotes.should == 2
-      s.user.karma.should == 1
+      expect(s.upvotes).to eq(2)
+      expect(s.user.karma).to eq(1)
     end
   end
 
   it "has no effect on a story score when casting a hide vote" do
     s = Story.make!
-    s.upvotes.should == 1
+    expect(s.upvotes).to eq(1)
 
     u = User.make!
 
     Vote.vote_thusly_on_story_or_comment_for_user_because(0, s.id,
       nil, u.id, "H")
     s.reload
-    s.user.karma.should == 0
-    s.upvotes.should == 1
-    s.downvotes.should == 0
+    expect(s.user.karma).to eq(0)
+    expect(s.upvotes).to eq(1)
+    expect(s.downvotes).to eq(0)
   end
 
   it "removes karma and upvote when downvoting an upvote" do
     s = Story.make!
     c = Comment.make!(:story_id => s.id)
-    c.user.karma.should == 0
+    expect(c.user.karma).to eq(0)
 
     u = User.make!
 
     Vote.vote_thusly_on_story_or_comment_for_user_because(1, s.id,
       c.id, u.id, nil)
     c.reload
-    c.user.karma.should == 1
+    expect(c.user.karma).to eq(1)
     # initial poster upvote plus new user's vote
-    c.upvotes.should == 2
-    c.downvotes.should == 0
+    expect(c.upvotes).to eq(2)
+    expect(c.downvotes).to eq(0)
 
     # flip vote
     Vote.vote_thusly_on_story_or_comment_for_user_because(-1, s.id,
       c.id, u.id, Vote::COMMENT_REASONS.keys.first)
     c.reload
 
-    c.user.karma.should == -1
-    c.upvotes.should == 1
-    c.downvotes.should == 1
+    expect(c.user.karma).to eq(-1)
+    expect(c.upvotes).to eq(1)
+    expect(c.downvotes).to eq(1)
   end
 
   it "neutralizes karma and upvote when unvoting an upvote" do
@@ -83,16 +83,16 @@ describe Vote do
     Vote.vote_thusly_on_story_or_comment_for_user_because(1, s.id,
       c.id, u.id, nil)
     c.reload
-    c.user.karma.should == 1
-    c.upvotes.should == 2
-    c.downvotes.should == 0
+    expect(c.user.karma).to eq(1)
+    expect(c.upvotes).to eq(2)
+    expect(c.downvotes).to eq(0)
 
     Vote.vote_thusly_on_story_or_comment_for_user_because(0, s.id,
       c.id, u.id, nil)
     c.reload
 
-    c.user.karma.should == 0
-    c.upvotes.should == 1
-    c.downvotes.should == 0
+    expect(c.user.karma).to eq(0)
+    expect(c.upvotes).to eq(1)
+    expect(c.downvotes).to eq(0)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -31,4 +30,5 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
 
   config.infer_spec_type_from_file_location!
+  config.raise_errors_for_deprecations!
 end


### PR DESCRIPTION
the :should syntax is no longer supported. Now we use the modern :expect syntax

This removes the deprecation warnings in the tests.