### PR TITLE
Add tableheader for invite deletion

### DIFF
--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -15,9 +15,7 @@
     <th width="20%">Name</th>
     <th width="40%">Memo</th>
     <th width="15%"></th>
-    <% if @user.is_moderator? %>
-      <th></th>
-    <% end %>
+    <th width="10%"></th>
   </tr>
   <% bit = 0 %>
   <% @invitation_requests.each do |ir| %>


### PR DESCRIPTION
Commit b592aae9 allowed the _Delete_ option for non-moderators, but didn't add the `<th></th>` to extend the grey tableheader bar over the new option. This adds an empty `<th>` cell like the one over _Send Invitation_.