### PR TITLE
added "json" to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "json"
 gem "rails", "~> 5.1"
 
 gem "unicorn"


### PR DESCRIPTION
I got the following error until I added "json" to the Gemfile, when trying to install lobsters

rake db:schema:load
rake aborted!
LoadError: cannot load such file -- json
/home/ec2-user/.gem/ruby/2.3/gems/activesupport-5.1.1/lib/active_support/core_ext/object/json.rb:2:in `require'