### PR TITLE
added step of installing Nodejs, so uglifier works

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ file.
          $ cd lobsters
          lobsters$
 
+* Install Nodejs, needed (or other execjs) for uglifier
+
+         Fedora: sudo yum install nodejs
+         Ubuntu: sudo apt-get install nodejs
+         OSX: brew install nodejs
+
 * Run Bundler to install/bundle gems needed by the project:
 
          lobsters$ bundle


### PR DESCRIPTION
I got this error, and found that Nodejs install was the workaround.

[ec2-user@www lobsters]$ rake db:schema:load --trace
rake aborted!
Bundler::GemRequireError: There was an error while trying to load the gem 'uglifier'.
Gem Load Error is: Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.

found this solution here: https://stackoverflow.com/questions/34420554/there-was-an-error-while-trying-to-load-the-gem-uglifier-bundlergemrequire

hope this helps