### PR TITLE
Update delete, reply, edit links to be tabable

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -64,24 +64,24 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
 
         <% if comment.is_editable_by_user?(@user) %>
           |
-          <a class="comment_editor">edit</a>
+          <a tabindex="0" class="comment_editor">edit</a>
         <% end %>
 
         <% if comment.is_gone? && comment.is_undeletable_by_user?(@user) %>
           |
-          <a class="comment_undeletor">undelete</a>
+          <a tabindex="0" class="comment_undeletor">undelete</a>
         <% elsif !comment.is_gone? && comment.is_deletable_by_user?(@user) %>
           |
           <% if @user && @user.is_moderator? && @user.id != comment.user_id %>
-            <a class="comment_moderator">delete</a>
+            <a tabindex="0" class="comment_moderator">delete</a>
           <% else %>
-            <a class="comment_deletor">delete</a>
+            <a tabindex="0" class="comment_deletor">delete</a>
           <% end %>
         <% end %>
 
         <% if @user && !comment.story.is_gone? && !comment.is_gone? %>
             |
-            <a class="comment_replier" unselectable="on">reply</a>
+            <a tabindex="0" class="comment_replier" unselectable="on">reply</a>
         <% end %>
 
         <% if defined?(show_story) && show_story %>


### PR DESCRIPTION
Currently the delete, reply, and edit links on comments are skipped over when
using the tab key to flip through the various links. Adding an href allows tab
to navigate to these links, and `javascript:void(0)` prevents the page from
scrolling when these links are clicked.

Thanks again for the awesome site! Glad to make any edits to this you deem necessary, just thought I'd submit a quick patch since I noticed this the other day when using the site without a mouse.