### PR TITLE
Add "user_is_author" to a story's json

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -305,6 +305,7 @@ class Story < ApplicationRecord
       { :description => :markeddown_description },
       :comments_url,
       { :submitter_user => :user },
+      :user_is_author,
       { :tags => self.tags.map(&:tag).sort },
     ]
 


### PR DESCRIPTION
I'm writing a bot to process "hottest.json" for my morning feed, and realized this missing field would be useful for rendering the story summary.
